### PR TITLE
Set max retry time & Set max page when downloading videos from users

### DIFF
--- a/iwara-dl.sh
+++ b/iwara-dl.sh
@@ -38,6 +38,7 @@ optional arguments:
   --load-ignore-list [File] load the list in file that should not download
   -r --retry [Count]        try to redownload the video at most [Count] times if not download completely
   --user                    treat input url as usernames
+  --max-page [Maxpage]      only download users' videos from page 1 to [Maxpage]
   --cduser-dir              cd to each user directory
   --quiet-mode              quiet mode
   --login                   log in upfront
@@ -92,6 +93,10 @@ while true; do
         --user )
             export PARSE_AS="username";
             shift; ;;
+        
+        --max-page )
+            export MAX_PAGE="$2"
+            shift 2; ;;
 
         --cduser-dir )
             export CDUSER="TRUE";

--- a/iwara-dl.sh
+++ b/iwara-dl.sh
@@ -36,8 +36,7 @@ optional arguments:
   --username [U]            username
   --userpass [P]            password
   --load-ignore-list [File] load the list in file that should not download
-  -r --resume               try resume download
-  --retry                   try to redownload the video if not download completely
+  -r --retry [Count]        try to redownload the video at most [Count] times if not download completely
   --user                    treat input url as usernames
   --cduser-dir              cd to each user directory
   --quiet-mode              quiet mode
@@ -84,9 +83,11 @@ while true; do
             iwara-login;
             shift; ;;
 
-        --retry )
+        -r | --retry )
+            export RETRY_COUNT=0;
+            export MAX_RETRY_COUNT="$2";
             export IWARA_RETRY="TRUE";
-            shift; ;;
+            shift 2; ;;
 
         --user )
             export PARSE_AS="username";
@@ -119,11 +120,6 @@ while true; do
 
         --name-only )
             export PRINT_NAME_ONLY="--silent";
-            shift; ;;
-
-        -r | --resume )
-            export RESUME_DL="TRUE";
-            export OPT_SET_RESUME_DL="TRUE";
             shift; ;;
 
         --updater-v1 )

--- a/iwaralib.sh
+++ b/iwaralib.sh
@@ -231,6 +231,8 @@ iwara-dl-update-user()
     if [[ "$SHALLOW_UPDATE" ]]; then
         IWARA_QUIET="TRUE"
         iwara-dl-user "$user" "0" # set $2(max_page) == 0
+    elif [[ "$MAX_PAGE" ]]; then
+        iwara-dl-user "$user" "$MAX_PAGE"
     else
         iwara-dl-user "$user"
     fi


### PR DESCRIPTION
This is the PR to resolve the retry issue #17  , and to enable the script to set max page when downloading videos from users. It also remove the redundant 'resume' argument.
